### PR TITLE
Replace old nodeupdate() with new minetest.check_for_falling()

### DIFF
--- a/tools.lua
+++ b/tools.lua
@@ -56,6 +56,6 @@ minetest.register_on_punchnode(function(pos, node, puncher)
 	and minetest.get_node(pos).name ~= "air" then
 		minetest.log("action", puncher:get_player_name() .. " digs " .. minetest.get_node(pos).name .. " at " .. minetest.pos_to_string(pos) .. " using an Admin Pickaxe.")
 		minetest.remove_node(pos) -- The node is removed directly, which means it even works on non-empty containers and group-less nodes.
-		nodeupdate(pos) -- Run node update actions like falling nodes.
+		minetest.check_for_falling(pos) -- Run node update actions like falling nodes.
 	end
 end)


### PR DESCRIPTION
Otherwise maptools crashes on 0.5.0-dev.

This is not tested, but should work.