### PR TITLE
Move maptools.drop_msg above dofiles

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -16,14 +16,14 @@ local S, NS = dofile(modpath .. "/intllib.lua")
 maptools.S = S
 maptools.NS = NS
 
+maptools.drop_msg = function(itemstack, player)
+	local name = player:get_player_name()
+	minetest.chat_send_player(name, S("[maptools] tools/nodes do not drop!"))
+end
+
 dofile(modpath .. "/config.lua")
 dofile(modpath .. "/aliases.lua")
 dofile(modpath .. "/craftitems.lua")
 dofile(modpath .. "/default_nodes.lua")
 dofile(modpath .. "/nodes.lua")
 dofile(modpath .. "/tools.lua")
-
-maptools.drop_msg = function(itemstack, player)
-	local name = player:get_player_name()
-	minetest.chat_send_player(name, S("[maptools] tools/nodes do not drop!"))
-end


### PR DESCRIPTION
Maptools tools/items have become droppable again, the function to prevent this is loaded after nodes.lua, leading the on_drop function to be nil.