### PR TITLE
Add `maptools` to the list of Luacheck globals

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -3,6 +3,10 @@ unused_args = false
 allow_defined_top = true
 max_line_length = 90
 
+globals = {
+	"maptools"
+}
+
 stds.minetest = {
 	read_globals = {
 		"DIR_DELIM",


### PR DESCRIPTION
This PR adds the global "maptools" to the luacheck-rc
I have no clue why your ci-system does not fail without this :shrug: 
the local `luacheck` fails otherwise