### PR TITLE
Fix node name for light-bulb in docs

### DIFF
--- a/docs/NODES_ITEMS.md
+++ b/docs/NODES_ITEMS.md
@@ -25,7 +25,7 @@ as they cannot be removed by hand (they can only be removed with
 | `maptools:kill`         | :warning: Instant kill blocks (damages players by 20 HP per second).                                                                                                   |
 | `maptools:drowning`     | :warning: Simulates drowning in water.                                                                                                                                 |
 | `maptools:light_block`  | :warning: Invisible non-solid block, prevents light from passing through.                                                                                              |
-| `maptools:lightbulb`   | :warning: Invisible non-solid block, emitting the maximum amount of light.                                                                                             |
+| `maptools:lightbulb`   | :warning: Invisible non-solid block, emitting the maximum amount of light.                                                                                              |
 
 ## Items
 

--- a/docs/NODES_ITEMS.md
+++ b/docs/NODES_ITEMS.md
@@ -25,7 +25,7 @@ as they cannot be removed by hand (they can only be removed with
 | `maptools:kill`         | :warning: Instant kill blocks (damages players by 20 HP per second).                                                                                                   |
 | `maptools:drowning`     | :warning: Simulates drowning in water.                                                                                                                                 |
 | `maptools:light_block`  | :warning: Invisible non-solid block, prevents light from passing through.                                                                                              |
-| `maptools:light_bulb`   | :warning: Invisible non-solid block, emitting the maximum amount of light.                                                                                             |
+| `maptools:lightbulb`   | :warning: Invisible non-solid block, emitting the maximum amount of light.                                                                                             |
 
 ## Items
 


### PR DESCRIPTION
node-name is `maptools:lightbulb`

https://github.com/minetest-mods/maptools/blob/d11b3a1caf2c8bac5621f3f211dc8a410129ad38/nodes.lua#L266-L280